### PR TITLE
Fix embedding loading and detection panel

### DIFF
--- a/src/core/face_engine.py
+++ b/src/core/face_engine.py
@@ -71,7 +71,8 @@ class FaceRecognitionEngine:
             for customer in recent_customers:
                 if customer['embedding'] is not None:
                     try:
-                        embedding = np.frombuffer(customer['embedding'], dtype=np.float32)
+                        # Embeddings are stored using pickle to preserve dtype/shape
+                        embedding = pickle.loads(customer['embedding'])
                         self.customer_database[customer['customer_id']] = embedding
                         loaded_customers += 1
                     except Exception as e:

--- a/src/ui/dashboard.py
+++ b/src/ui/dashboard.py
@@ -217,12 +217,16 @@ class HotelDashboard:
         detections_frame = ttk.LabelFrame(right_panel, text="🔍 Live Detections", padding=5)
         detections_frame.pack(fill=tk.BOTH, expand=True, pady=5)
 
-        columns = ('Time', 'Type', 'ID', 'Confidence', 'Status')
+        # Include an Info column to display visit counts or names
+        columns = ('Time', 'Type', 'ID', 'Info', 'Confidence', 'Status')
         self.recent_tree = ttk.Treeview(detections_frame, columns=columns, show='headings', height=8)
 
         for col in columns:
+            width = 80
+            if col == 'Info':
+                width = 120
             self.recent_tree.heading(col, text=col)
-            self.recent_tree.column(col, width=80)
+            self.recent_tree.column(col, width=width)
 
         detection_scrollbar = ttk.Scrollbar(detections_frame, orient=tk.VERTICAL, command=self.recent_tree.yview)
         self.recent_tree.configure(yscrollcommand=detection_scrollbar.set)
@@ -885,7 +889,7 @@ class HotelDashboard:
                 status = "Active" if person_type in ["Customer", "Staff"] else "New"
 
                 new_item = self.recent_tree.insert('', 0, values=(
-                    timestamp, person_type, person_id, confidence_str, status
+                    timestamp, person_type, person_id, name, confidence_str, status
                 ))
 
                 # Limit to 30 items for performance


### PR DESCRIPTION
## Summary
- load pickled customer embeddings so face recognition can match stored visitors
- expand dashboard detection table with an Info column showing visit counts and names

## Testing
- `python -m py_compile src/core/face_engine.py src/ui/dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_688e246e03cc832293745486a41248a4