### PR TITLE
feat: make confidence threshold configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ python main.py
 - **Monthly Reports**: Summary statistics
 - **Real-time Dashboard**: Live visitor information
 
+## Recognition Tuning
+
+### Confidence Threshold
+Adjust how strictly embeddings must match to identify a person. Lower values
+such as `0.55` increase matches but risk false positives, while higher values
+around `0.7` improve precision at the cost of missed identifications. The
+default can be modified via the `confidence_threshold` setting in
+`config/settings.json` to reflect real-world performance.
+
 ## Troubleshooting
 
 ### Camera Issues

--- a/config/settings.json
+++ b/config/settings.json
@@ -1,4 +1,5 @@
 {
+    "confidence_threshold": 0.55,
     "camera": {
         "source_type": "ip",
         "resolution": "1280x720",
@@ -8,3 +9,4 @@
         "rtsp_url": "rtsp://admin:Ikhlas@123@192.168.1.12:554/Streaming/Channels/101"
     }
 }
+

--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -26,7 +26,11 @@ class ConfigManager:
             "min_face_size": 50,
             "gpu_enabled": True,
             "language": "english",
-            "theme": "default"
+            "theme": "default",
+            # Adjustable face recognition match threshold. Lower values increase
+            # matches but may introduce false positives. Recommended range:
+            # 0.55-0.7 based on environment.
+            "confidence_threshold": 0.55,
         }
         
         if os.path.exists(self.settings_file):

--- a/src/core/face_engine.py
+++ b/src/core/face_engine.py
@@ -22,7 +22,11 @@ class FaceRecognitionEngine:
         # Research-backed threshold settings
         # MODIFIED: Lowered thresholds for better real-world detection
         self.min_face_size = 60  # Changed from 80
-        self.confidence_threshold = 0.55
+        # Allow configurable match threshold; default tuned for balanced
+        # precision/recall. Users can adjust via ConfigManager settings.json.
+        self.confidence_threshold = self.config.get_setting(
+            "confidence_threshold", 0.55
+        )
         self.detection_threshold = 0.6  # Changed from 0.65
         self.quality_threshold = 0.7
 


### PR DESCRIPTION
## Summary
- expose `confidence_threshold` setting in ConfigManager with guidance
- load threshold from settings in FaceRecognitionEngine
- document tuning and recommended ranges

## Testing
- `pytest`
- `python -m py_compile src/core/config_manager.py src/core/face_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_688e27d7e3d883228e0080c8f9e9b957