### PR TITLE
Set 1080p camera defaults

### DIFF
--- a/config/camera_settings.json
+++ b/config/camera_settings.json
@@ -1,6 +1,6 @@
 {
     "source_type": "rtsp",
-    "resolution": "2560x1440",
+    "resolution": "1920x1080",
     "fps": 25,
     "buffer_size": 5,
     "transport": "UDP",

--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -84,7 +84,7 @@ class ConfigManager:
             "source_type": "usb",
             "rtsp_url": "rtsp://admin:password@192.168.1.100:554/stream1",
             "usb_index": 0,
-            "resolution": "1280x720",
+            "resolution": "1920x1080",
             "fps": 25,
             "buffer_size": 5,
             "transport": "TCP"

--- a/src/ui/camera_setup.py
+++ b/src/ui/camera_setup.py
@@ -82,10 +82,13 @@ class CameraSetupWindow:
         
         # Resolution
         ttk.Label(advanced_frame, text="Resolution:").grid(row=0, column=0, sticky=tk.W, pady=5)
-        self.resolution_var = tk.StringVar(value="1280x720")
-        resolution_combo = ttk.Combobox(advanced_frame, textvariable=self.resolution_var,
-                                       values=["640x480", "1280x720", "1920x1080", "2560x1440"],
-                                       width=12)
+        self.resolution_var = tk.StringVar(value="1920x1080")
+        resolution_combo = ttk.Combobox(
+            advanced_frame,
+            textvariable=self.resolution_var,
+            values=["640x480", "1280x720", "1920x1080"],
+            width=12,
+        )
         resolution_combo.grid(row=0, column=1, sticky=tk.W, pady=5, padx=5)
         
         # FPS


### PR DESCRIPTION
## Summary
- default camera resolution set to 1920x1080
- restrict resolution choices in UI to 1080p and below
- align ConfigManager default resolution with new UI default

## Testing
- `python - <<'PY'
import tempfile, shutil
from src.core.config_manager import ConfigManager
print('Testing default camera settings when no file exists:')
tmpdir = tempfile.mkdtemp()
cm = ConfigManager(config_dir=tmpdir)
settings = cm.get_camera_settings()
print(settings)
assert settings.get('resolution') == '1920x1080', 'Default resolution mismatch'
shutil.rmtree(tmpdir)
PY`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68905f6456ec83229f2be6573ff9e507