### PR TITLE
Improve visits overlay visibility

### DIFF
--- a/src/ui/dashboard.py
+++ b/src/ui/dashboard.py
@@ -1133,10 +1133,11 @@ class HotelDashboard:
                                 cv2.putText(frame, line, (x1, text_y),
                                            cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 2)
                         
-                        # **CRITICAL: Draw visits message BELOW the face**
+                        # **CRITICAL: Draw visits message ABOVE the face for visibility**
                         if visits_message:
-                            cv2.putText(frame, visits_message, (x1, y2 + 20),
-                                       cv2.FONT_HERSHEY_SIMPLEX, 0.5, (255, 255, 255), 2)
+                            text_pos = (x1, max(40, y1 - 40))
+                            cv2.putText(frame, visits_message, text_pos,
+                                       cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 255, 255), 2)
                         
                         # Draw confidence
                         cv2.putText(frame, f"Conf: {confidence:.3f}", (x1, y1-5),

--- a/test_visits_overlay.py
+++ b/test_visits_overlay.py
@@ -1,0 +1,14 @@
+import numpy as np
+import cv2
+
+def draw_visits_text(width, height):
+    frame = np.zeros((height, width, 3), dtype=np.uint8)
+    x1, y1 = 100, 100
+    text_pos = (x1, max(40, y1 - 40))
+    cv2.putText(frame, "Total Visits: 5", text_pos, cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 255, 255), 2)
+    region = frame[text_pos[1]-5:text_pos[1]+5, text_pos[0]:text_pos[0]+150]
+    return np.any(region > 0)
+
+def test_overlay_legibility_hd_frames():
+    assert draw_visits_text(1920, 1080)
+    assert draw_visits_text(1980, 1080)


### PR DESCRIPTION
## Summary
- Show total visits label above detected faces for better readability.
- Increase overlay font size for HD frames.
- Add regression test confirming visits text renders on 1920×1080 and 1980×1080 frames.

## Testing
- `pytest -q test_visits_overlay.py`


------
https://chatgpt.com/codex/tasks/task_e_6890899629bc83228889ede9bec417f5